### PR TITLE
Adding Travis CI Support For ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: xenial
 language: python
+arch: 
+- 'arm64'
+- 'amd64'
 python:
 - '3.7'
 install:


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI.